### PR TITLE
Persist wallpaper change to user's profile

### DIFF
--- a/wallpaper.c
+++ b/wallpaper.c
@@ -21,7 +21,7 @@ int wmain(int argc, wchar_t **argv) {
 			return 1;
 		}
 
-		if (!SystemParametersInfoW(SPI_SETDESKWALLPAPER, 0, fullPath, SPIF_SENDCHANGE)) {
+		if (!SystemParametersInfoW(SPI_SETDESKWALLPAPER, 0, fullPath, SPIF_UPDATEINIFILE | SPIF_SENDCHANGE)) {
 			fputs("Failed to set the desktop wallpaper", stderr);
 			return 1;
 		}


### PR DESCRIPTION
Closes https://github.com/sindresorhus/wallpaper/issues/47

The `SPIF_UPDATEINIFILE` flag must be set to write the change to the users profile. Without this flag, the change is for the current session only.

---
References:
[1] https://www.pinvoke.net/default.aspx/Enums.SPIF
[2] https://blogs.msdn.microsoft.com/oldnewthing/20160721-00/?p=93925
