### PR TITLE
Fix Error Handling and Return Code

### DIFF
--- a/wallpaper.cpp
+++ b/wallpaper.cpp
@@ -61,8 +61,10 @@ int wmain(int argc, wchar_t **argv) {
 	if (argc <= 1) {
 		wchar_t imagePath[MAX_PATH];
 		if (GetWallpaper(imagePath) == 0) {
+			imagePath[MAX_PATH - 1] = L'\0';
 			wprintf(L"%ls\n", imagePath);
 		}
+		return 0;
 	}
 
 	if (wcscmp(argv[1], L"--version") == 0) {


### PR DESCRIPTION
- Fix an issue that prevents `stdout` from the binary from being read due to invalid memory addresses.
- Error handling improvements for GetWallpaper.

Here is the zipped binary:
[binary.zip](https://github.com/sindresorhus/win-wallpaper/files/10560084/binary.zip)
